### PR TITLE
docs: unfold right sidebar to second level

### DIFF
--- a/docs/appendices/tips.md
+++ b/docs/appendices/tips.md
@@ -58,7 +58,7 @@ You will download around **1 GB** of source code.
 IDE that is regularly updated, is configurable with easy-to-access `json`
 files, and offers a growing number of user-developed extensions. In recent
 years, it is has become
-[the most widely used editor](https://insights.stackoverflow.com/survey/2021#collaboration-tools)
+[the most widely used editor](https://insights.stackoverflow.com/survey/2021#section-most-popular-technologies-integrated-development-environment)
 on the market.
 
 For working with VSCode on `lxslc`, you can use the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -196,7 +196,7 @@ myst_update_mathjax = False
 comments_config = {
     "hypothesis": True,
     "utterances": {
-        "repo": f"ComPWA/{REPO_NAME}",
+        "repo": f"redeboer/{REPO_NAME}",
         "issue-term": "pathname",
         "label": "📝 Docs",
     },

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,6 +120,7 @@ html_theme_options = {
         "thebelab": True,
     },
     "show_navbar_depth": 2,
+    "show_toc_level": 2,
     "theme_dev_mode": True,
 }
 html_title = "BOSS Documentation"

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -20,6 +20,9 @@ source code for the page in
 problems can be reported by opening an issue. In both cases, you will need to
 [create a GitHub account](https://github.com/join).
 
+Alternatively, just directly highlight or make notes on these pages. With a
+[Hypothesis.is](https://hypothes.is) you can then post those notes as feedback.
+
 ## Developing these pages
 
 :::{tip}

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,9 @@ you have access to the software of this collaboration. You can also have a look
 at the links in the section {doc}`appendices/references`.
 ```
 
-## Contents of the tutorial pages
+```{rubric} Contents of the tutorial pages
+
+```
 
 Here are shortcuts that you might want to take:
 


### PR DESCRIPTION
Follow-up to #31, now for the right sidebar ([secondary sidebar](https://sphinx-book-theme.readthedocs.io/en/latest/customize/sidebar-secondary.html)). Preview [here](https://bes3--34.org.readthedocs.build/appendices/tips.html).