### PR TITLE
MAINT: update pip constraints and pre-commit

### DIFF
--- a/.constraints/py3.10.txt
+++ b/.constraints/py3.10.txt
@@ -114,7 +114,7 @@ rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
 rpds-py==0.18.0
 ruff==0.3.5
-send2trash==1.8.2
+send2trash==1.8.3
 six==1.16.0
 sniffio==1.3.1
 snowballstemmer==2.2.0

--- a/.constraints/py3.11.txt
+++ b/.constraints/py3.11.txt
@@ -113,7 +113,7 @@ rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
 rpds-py==0.18.0
 ruff==0.3.5
-send2trash==1.8.2
+send2trash==1.8.3
 six==1.16.0
 sniffio==1.3.1
 snowballstemmer==2.2.0

--- a/.constraints/py3.12.txt
+++ b/.constraints/py3.12.txt
@@ -113,7 +113,7 @@ rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
 rpds-py==0.18.0
 ruff==0.3.5
-send2trash==1.8.2
+send2trash==1.8.3
 six==1.16.0
 sniffio==1.3.1
 snowballstemmer==2.2.0

--- a/.constraints/py3.7.txt
+++ b/.constraints/py3.7.txt
@@ -116,7 +116,7 @@ requests==2.31.0
 rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
 ruff==0.3.5
-send2trash==1.8.2
+send2trash==1.8.3
 six==1.16.0
 sniffio==1.3.1
 snowballstemmer==2.2.0

--- a/.constraints/py3.8.txt
+++ b/.constraints/py3.8.txt
@@ -119,7 +119,7 @@ rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
 rpds-py==0.18.0
 ruff==0.3.5
-send2trash==1.8.2
+send2trash==1.8.3
 six==1.16.0
 sniffio==1.3.1
 snowballstemmer==2.2.0

--- a/.constraints/py3.9.txt
+++ b/.constraints/py3.9.txt
@@ -115,7 +115,7 @@ rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
 rpds-py==0.18.0
 ruff==0.3.5
-send2trash==1.8.2
+send2trash==1.8.3
 six==1.16.0
 sniffio==1.3.1
 snowballstemmer==2.2.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-ast
       - id: check-case-conflict
@@ -57,7 +57,7 @@ repos:
         exclude: (?x)^(labels.*\.toml)$
 
   - repo: https://github.com/ComPWA/policy
-    rev: 0.3.4
+    rev: 0.3.5
     hooks:
       - id: check-dev-files
         args:


### PR DESCRIPTION
This PR updates the [`pip` constraint files](https://github.com/ComPWA/update-pip-constraints?tab=readme-ov-file#update-pip-constraint-files) under the `.constraints/` directory and pre-commit hooks in [`.pre-commit-config.yaml`](https://pre-commit.com). It was created automatically by a scheduled workflow.