### PR TITLE
DOC: update login and setup instructions

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -127,6 +127,7 @@
     "INFN",
     "jupyter",
     "kalman",
+    "lxlogin",
     "parametrizations",
     "prepend",
     "PyPA",

--- a/.cspell.json
+++ b/.cspell.json
@@ -111,6 +111,7 @@
     "arXiv",
     "BaskeAnaTool",
     "bepc",
+    "beslogin",
     "breit",
     "cern",
     "charmonium",

--- a/tutorials/getting-started/server.qmd
+++ b/tutorials/getting-started/server.qmd
@@ -12,7 +12,11 @@ The IHEP server runs on [AlmaLinux9](https://almalinux.org/) .
 ssh -Y <Your IHEP computing cluster account>@lxlogin.ihep.ac.cn
 ```
 
-:::{.callout-note}
+Here, the option `-Y` ensures _X11 forwarding_, allowing you to open graphical applications from the server.
+
+:::{.callout-warning}
+The computing cluster account is different from your IHEP account name. It can be found by logging in to [https://login.ihep.ac.cn/](https://login.ihep.ac.cn/) and clicking on your name. The account name is listed under "IHEP computing cluster account".
+:::
 
 To simplify the login process, you can first create the `~/.ssh/cm/` directory via
 
@@ -22,7 +26,7 @@ mkdir -p ~/.ssh/cm
 
 and then add the following lines to your `~/.ssh/config` file:
 
-````bash
+```bash
 Host ihep
   HostName lxlogin.ihep.ac.cn
 Match host beslogin.ihep.ac.cn,lxlogin.ihep.ac.cn
@@ -31,12 +35,7 @@ Match host beslogin.ihep.ac.cn,lxlogin.ihep.ac.cn
   ControlPersist 10m
   PreferredAuthentications password
   User USERNAME
-
-:::
-:::{.callout-warning}
-The computing cluster account is different from your IHEP account name. It can be found by logging in to [https://login.ihep.ac.cn/](https://login.ihep.ac.cn/) and clicking on your name. The account name is listed under "IHEP computing cluster account".
-:::
-Here, the option `-Y` ensures _X11 forwarding_, allowing you to open graphical applications from the server.
+```
 
 :::{.callout-note}
 If you don't like having to enter your password every time you log in, have a look at the section [Key generation for SSH](/appendices/tips.qmd#ssh-keygen).
@@ -50,16 +49,16 @@ In order to do this you need to add it to your `PATH` variable by running
 
 ```bash
 export PATH=/cvmfs/container.ihep.ac.cn/bin/:$PATH
-````
+```
 
-Once you have done this, you can switch to the SLC version of your choice by running
+Once you have done this, you can switch to the version of your choice by running
 
 ```bash
 hep_container shell CentOS7
 ```
 
 where `shell` can be replaced with your shell of choice.
-The available SLC versions can be found by running `hep_container images`.
+The available versions can be found by running `hep_container images`.
 :::
 
 ## Important data paths {#data-paths}
@@ -89,3 +88,7 @@ For the latest data file locations, see [this page](https://docbes3.ihep.ac.cn/~
 ## Changing to your preferred shell
 
 By default, the shell for your user account is set to [`tcsh`](https://en.wikipedia.org/wiki/Tcsh). You can apply for other shells like `bash`, `csh`, and `zsh` through [ccsuser.ihep.ac.cn](https://ccsuser.ihep.ac.cn) and then clicking "Apply to change default shell". <!-- cspell:ignore ccsuser -->
+
+```
+
+```

--- a/tutorials/getting-started/server.qmd
+++ b/tutorials/getting-started/server.qmd
@@ -59,7 +59,11 @@ hep_container shell CentOS7
 ```
 
 where `shell` can be replaced with your shell of choice.
-The available SLC versions can be found by running `hep_container images`.
+The available SLC versions can be found by running
+
+```bash
+hep_container images
+```
 :::
 
 ## Important data paths {#data-paths}

--- a/tutorials/getting-started/server.qmd
+++ b/tutorials/getting-started/server.qmd
@@ -6,16 +6,16 @@ Within BESIII, most analysis tasks are run on a server that is hosted by {{< glo
 
 ## Accessing the server
 
-The IHEP server runs on [AlmaLinux9](https://almalinux.org/) .
+The IHEP server runs on [AlmaLinux9](https://almalinux.org/). The server can be accessed through SSH using:
 
 ```bash
-ssh -Y <Your IHEP computing cluster account>@lxlogin.ihep.ac.cn
+ssh -Y USERNAME@lxlogin.ihep.ac.cn
 ```
 
-Here, the option `-Y` ensures _X11 forwarding_, allowing you to open graphical applications from the server.
+where `USERNAME` is your IHEP computing cluster account. The option `-Y` is optional and ensures _X11 forwarding_, allowing you to open graphical applications from the server.
 
 :::{.callout-warning}
-The computing cluster account is different from your IHEP account name. It can be found by logging in to [https://login.ihep.ac.cn/](https://login.ihep.ac.cn/) and clicking on your name. The account name is listed under "IHEP computing cluster account".
+The computing cluster account is different from your IHEP account name. It can be found by logging in to [login.ihep.ac.cn](https://login.ihep.ac.cn) and clicking on your name. The account name is listed under "IHEP computing cluster account".
 :::
 
 To simplify the login process, you can first create the `~/.ssh/cm/` directory via
@@ -34,8 +34,10 @@ Match host beslogin.ihep.ac.cn,lxlogin.ihep.ac.cn
   ControlPath ~/.ssh/cm/%C.sock
   ControlPersist 10m
   PreferredAuthentications password
-  User USERNAME
+  User USERNAME  # <1>
 ```
+
+1. Again, `USERNAME` should be replaced with your IHEP computing cluster account name.
 
 :::{.callout-note}
 If you don't like having to enter your password every time you log in, have a look at the section [Key generation for SSH](/appendices/tips.qmd#ssh-keygen).
@@ -44,8 +46,7 @@ If you don't like having to enter your password every time you log in, have a lo
 In Windows, there are some nice tools that allow you to access the server. First of all, to be able to use SSH, use will either have to use [PuTTY](https://www.putty.org/) or more extensive software like [Xmanager](https://www.netsarang.com/en/xmanager/). You can also just search for some Linux terminals for Windows. In addition, have a look at the (S)FTP client [WinSCP](https://winscp.net/eng/index.php). It allows you to easily navigate the file structure of the IHEP server and to quickly transfer―even synchronize―files up and down to your own computer. <!-- cspell:ignore Xmanager -->
 
 :::{.callout-note}
-Once in the server, you can switch to other linux versions using `hep_container`:
-In order to do this you need to add it to your `PATH` variable by running
+Once in the server, you can switch to other Linux versions using `hep_container`. In order to do this, you need to add it to your `PATH` variable by running
 
 ```bash
 export PATH=/cvmfs/container.ihep.ac.cn/bin/:$PATH
@@ -57,8 +58,7 @@ Once you have done this, you can switch to the version of your choice by running
 hep_container shell CentOS7
 ```
 
-where `shell` can be replaced with your shell of choice and `CentOS7` with your distribution of choice.
-The available distribution versions can be found by running:
+where `shell` can be replaced with your shell of choice and `CentOS7` with your distribution of choice. The available distribution versions can be found by running:
 
 ```bash
 hep_container images
@@ -93,7 +93,3 @@ For the latest data file locations, see [this page](https://docbes3.ihep.ac.cn/~
 ## Changing to your preferred shell
 
 By default, the shell for your user account is set to [`tcsh`](https://en.wikipedia.org/wiki/Tcsh). You can apply for other shells like `bash`, `csh`, and `zsh` through [ccsuser.ihep.ac.cn](https://ccsuser.ihep.ac.cn) and then clicking "Apply to change default shell". <!-- cspell:ignore ccsuser -->
-
-```
-
-```

--- a/tutorials/getting-started/server.qmd
+++ b/tutorials/getting-started/server.qmd
@@ -8,16 +8,21 @@ Within BESIII, most analysis tasks are run on a server that is hosted by {{< glo
 
 The IHEP server runs on [AlmaLinux9](https://almalinux.org/) .
 
-<!-- According to the BOSS 8 Upgrade Documentation, the computing nodes got upgraded from CentOS7 to AlmaLinux9 so this should no longer be relevant. The server offers several versions. Usually, people use either SLC5, SLC6, or SLC7. The domain names for these are `lxslc7.ihep.ac.cn`, where the `7` in this case refers to SLC7. If you are running on Linux or a Linux terminal, the server can be easily accessed using: -->
-
 ```bash
 ssh -Y <Your IHEP computing cluster account>@lxlogin.ihep.ac.cn
 ```
 
 :::{.callout-note}
-To simplify the login process, you can add the following lines to your `~/.ssh/config` file:
+
+To simplify the login process, you can first create the `~/.ssh/cm/` directory via
 
 ```bash
+mkdir -p ~/.ssh/cm
+```
+
+and then add the following lines to your `~/.ssh/config` file:
+
+````bash
 Host ihep
   HostName lxlogin.ihep.ac.cn
 Match host beslogin.ihep.ac.cn,lxlogin.ihep.ac.cn
@@ -26,10 +31,9 @@ Match host beslogin.ihep.ac.cn,lxlogin.ihep.ac.cn
   ControlPersist 10m
   PreferredAuthentications password
   User USERNAME
-```
 
 :::
-:::{.callout-note}
+:::{.callout-warning}
 The computing cluster account is different from your IHEP account name. It can be found by logging in to [https://login.ihep.ac.cn/](https://login.ihep.ac.cn/) and clicking on your name. The account name is listed under "IHEP computing cluster account".
 :::
 Here, the option `-Y` ensures _X11 forwarding_, allowing you to open graphical applications from the server.
@@ -41,12 +45,12 @@ If you don't like having to enter your password every time you log in, have a lo
 In Windows, there are some nice tools that allow you to access the server. First of all, to be able to use SSH, use will either have to use [PuTTY](https://www.putty.org/) or more extensive software like [Xmanager](https://www.netsarang.com/en/xmanager/). You can also just search for some Linux terminals for Windows. In addition, have a look at the (S)FTP client [WinSCP](https://winscp.net/eng/index.php). It allows you to easily navigate the file structure of the IHEP server and to quickly transfer―even synchronize―files up and down to your own computer. <!-- cspell:ignore Xmanager -->
 
 :::{.callout-note}
-Once in the server, you can switch to other versions of SLC using `hep_container`:
+Once in the server, you can switch to other linux versions using `hep_container`:
 In order to do this you need to add it to your `PATH` variable by running
 
 ```bash
 export PATH=/cvmfs/container.ihep.ac.cn/bin/:$PATH
-```
+````
 
 Once you have done this, you can switch to the SLC version of your choice by running
 

--- a/tutorials/getting-started/server.qmd
+++ b/tutorials/getting-started/server.qmd
@@ -64,6 +64,7 @@ The available SLC versions can be found by running
 ```bash
 hep_container images
 ```
+
 :::
 
 ## Important data paths {#data-paths}

--- a/tutorials/getting-started/server.qmd
+++ b/tutorials/getting-started/server.qmd
@@ -57,8 +57,8 @@ Once you have done this, you can switch to the version of your choice by running
 hep_container shell CentOS7
 ```
 
-where `shell` can be replaced with your shell of choice.
-The available SLC versions can be found by running
+where `shell` can be replaced with your shell of choice and `CentOS7` with your distribution of choice.
+The available distribution versions can be found by running:
 
 ```bash
 hep_container images

--- a/tutorials/getting-started/server.qmd
+++ b/tutorials/getting-started/server.qmd
@@ -6,12 +6,17 @@ Within BESIII, most analysis tasks are run on a server that is hosted by {{< glo
 
 ## Accessing the server
 
-The IHEP server runs on [Scientific Linux CERN](https://scientificlinux.org/) (SLC). The server offers several versions. Usually, people use either SLC5, SLC6, or SLC7. The domain names for these are `lxslc7.ihep.ac.cn`, where the `7` in this case refers to SLC7. If you are running on Linux or a Linux terminal, the server can be easily accessed using:
+The IHEP server runs on [AlmaLinux9](https://almalinux.org/) .
+
+<!-- According to the BOSS 8 Upgrade Documentation, the computing nodes got upgraded from CentOS7 to AlmaLinux9 so this should no longer be relevant. The server offers several versions. Usually, people use either SLC5, SLC6, or SLC7. The domain names for these are `lxslc7.ihep.ac.cn`, where the `7` in this case refers to SLC7. If you are running on Linux or a Linux terminal, the server can be easily accessed using: -->
 
 ```bash
-ssh -Y <your user name>@lxslc7.ihep.ac.cn
+ssh -Y <Your IHEP computing cluster account>@lxlogin.ihep.ac.cn
 ```
 
+:::{.callout-note}
+The computing cluster account is different from your IHEP account name. It can be found by logging in to [https://login.ihep.ac.cn/](https://login.ihep.ac.cn/) and clicking on your name. The account name is listed under "IHEP computing cluster account".
+:::
 Here, the option `-Y` ensures _X11 forwarding_, allowing you to open graphical applications from the server.
 
 :::{.callout-note}
@@ -21,13 +26,21 @@ If you don't like having to enter your password every time you log in, have a lo
 In Windows, there are some nice tools that allow you to access the server. First of all, to be able to use SSH, use will either have to use [PuTTY](https://www.putty.org/) or more extensive software like [Xmanager](https://www.netsarang.com/en/xmanager/). You can also just search for some Linux terminals for Windows. In addition, have a look at the (S)FTP client [WinSCP](https://winscp.net/eng/index.php). It allows you to easily navigate the file structure of the IHEP server and to quickly transfer―even synchronize―files up and down to your own computer. <!-- cspell:ignore Xmanager -->
 
 :::{.callout-note}
-Once in the server, you can switch to other versions of SLC using `hep_container`. So for instance, if you are in SLC7 (CentOS) and want to use SL6, you can use:
+Once in the server, you can switch to other versions of SLC using `hep_container`:
+In order to do this you need to add it to your `PATH` variable by running
 
 ```bash
-hep_container shell SL6
+export PATH=/cvmfs/container.ihep.ac.cn/bin/:$PATH
+```
+
+Once you have done this, you can switch to the SLC version of your choice by running
+
+```bash
+hep_container shell CentOS7
 ```
 
 where `shell` can be replaced with your shell of choice.
+The available SLC versions can be found by running `hep_container images`.
 :::
 
 ## Important data paths {#data-paths}

--- a/tutorials/getting-started/server.qmd
+++ b/tutorials/getting-started/server.qmd
@@ -15,6 +15,21 @@ ssh -Y <Your IHEP computing cluster account>@lxlogin.ihep.ac.cn
 ```
 
 :::{.callout-note}
+To simplify the login process, you can add the following lines to your `~/.ssh/config` file:
+
+```bash
+Host ihep
+  HostName lxlogin.ihep.ac.cn
+Match host beslogin.ihep.ac.cn,lxlogin.ihep.ac.cn
+  ControlMaster auto
+  ControlPath ~/.ssh/cm/%C.sock
+  ControlPersist 10m
+  PreferredAuthentications password
+  User USERNAME
+```
+
+:::
+:::{.callout-note}
 The computing cluster account is different from your IHEP account name. It can be found by logging in to [https://login.ihep.ac.cn/](https://login.ihep.ac.cn/) and clicking on your name. The account name is listed under "IHEP computing cluster account".
 :::
 Here, the option `-Y` ensures _X11 forwarding_, allowing you to open graphical applications from the server.

--- a/tutorials/getting-started/setup.qmd
+++ b/tutorials/getting-started/setup.qmd
@@ -66,9 +66,7 @@ Option `-p` makes `mkdir` work on arbitrary depth and ignores existing directori
 ```bash
 mkdir -p "$BOSS_INSTALL/cmthome"
 cd "$BOSS_INSTALL/cmthome"
-#cp -Rf /cvmfs/bes3.ihep.ac.cn/bes3sw/cmthome/cmthome-$BOSS_VERSION/* .
 cp -Rf /cvmfs/bes3.ihep.ac.cn/bes3sw/cmthome/my/cmthome-$BOSS_VERSION/* .
-# The directories aside from /my in cmthome do not contain the required setup.sh, while the /my/... directories do. The /my directories seem to contain additional files, but the setup and test work.
 ```
 
 Note that we have omitted the version from the original folder name. You can choose to keep that number as well, but here we chose to use the convention that `cmthome` and `workarea` without a version number refers to the latest stable version of BOSS.

--- a/tutorials/getting-started/setup.qmd
+++ b/tutorials/getting-started/setup.qmd
@@ -43,12 +43,12 @@ Why the quotation marks (`"..."`) and curly braces (`{...}`)? It's just a good h
 
 This variable points to the path that will contain your local 'install' of BOSS. You can change what is between the quotation marks by whatever folder you prefer, in case you want your local BOSS install to be placed in some other path, for instance by `/ihepbatch/bes/$USER`.
 
-At this stage, you'll have to decide which version of BOSS you have to use. For this example **version 7.1.3.b** is used, though it could be that for your analysis you have to use data sets that were reconstructed with older versions of BOSS. Here, we'll stick with `7.1.3.b`, but you can replace this number with whatever version you need.
+At this stage, you'll have to decide which version of BOSS you have to use. For this example **version 7.0.8** is used, though it could be that for your analysis you have to use data sets that were reconstructed with older versions of BOSS. Here, we'll stick with `7.0.8`, but you can replace this number with whatever version you need.
 
 For convenience, we'll again define the version number as a variable here.
 
 ```bash
-BOSS_VERSION="7.1.3.b"
+BOSS_VERSION="7.0.8"
 ```
 
 :::{.callout-tip}
@@ -203,7 +203,7 @@ These lines force the server to source your `.bashrc` run commands file when you
 
 ```{.bash filename=".bashrc"}
 export BOSS_INSTALL="/besfs5/users/${USER}/boss"
-export BOSS_VERSION="7.1.3.b"
+export BOSS_VERSION="7.0.8"
 CMTHOME="/cvmfs/bes3.ihep.ac.cn/bes3sw/cmthome/cmthome-${BOSS_VERSION}"
 
 source "${BOSS_INSTALL}/cmthome/setupCMT.sh"
@@ -226,7 +226,7 @@ The following summarizes all commands required to 'install' BOSS on `lxslc` on y
 
 ```bash
 BOSS_INSTALL=/besfs5/users/$USER/boss
-BOSS_VERSION=7.1.3.b
+BOSS_VERSION=7.0.8
 mkdir -p $BOSS_INSTALL/cmthome
 cd $BOSS_INSTALL/cmthome
 cp -Rf /cvmfs/bes3.ihep.ac.cn/bes3sw/cmthome/my/cmthome-$BOSS_VERSION/* .

--- a/tutorials/getting-started/setup.qmd
+++ b/tutorials/getting-started/setup.qmd
@@ -43,12 +43,12 @@ Why the quotation marks (`"..."`) and curly braces (`{...}`)? It's just a good h
 
 This variable points to the path that will contain your local 'install' of BOSS. You can change what is between the quotation marks by whatever folder you prefer, in case you want your local BOSS install to be placed in some other path, for instance by `/ihepbatch/bes/$USER`.
 
-At this stage, you'll have to decide which version of BOSS you have to use. At the time of writing, **version 7.0.5** is the latest stable version, though it could be that for your analysis you have to use data sets that were reconstructed with older versions of BOSS. Here, we'll stick with `7.0.5`, but you can replace this number with whatever version you need.
+At this stage, you'll have to decide which version of BOSS you have to use. For this example **version 7.1.3.b** is used, though it could be that for your analysis you have to use data sets that were reconstructed with older versions of BOSS. Here, we'll stick with `7.1.3.b`, but you can replace this number with whatever version you need.
 
 For convenience, we'll again define the version number as a variable here.
 
 ```bash
-BOSS_VERSION="7.0.5"
+BOSS_VERSION="7.1.3.b"
 ```
 
 :::{.callout-tip}
@@ -66,7 +66,9 @@ Option `-p` makes `mkdir` work on arbitrary depth and ignores existing directori
 ```bash
 mkdir -p "$BOSS_INSTALL/cmthome"
 cd "$BOSS_INSTALL/cmthome"
-cp -Rf /cvmfs/bes3.ihep.ac.cn/bes3sw/cmthome/cmthome-$BOSS_VERSION/* .
+#cp -Rf /cvmfs/bes3.ihep.ac.cn/bes3sw/cmthome/cmthome-$BOSS_VERSION/* .
+cp -Rf /cvmfs/bes3.ihep.ac.cn/bes3sw/cmthome/my/cmthome-$BOSS_VERSION/* .
+# The directories aside from /my in cmthome do not contain the required setup.sh, while the /my/... directories do. The /my directories seem to contain additional files, but the setup and test work.
 ```
 
 Note that we have omitted the version from the original folder name. You can choose to keep that number as well, but here we chose to use the convention that `cmthome` and `workarea` without a version number refers to the latest stable version of BOSS.
@@ -180,6 +182,9 @@ If not, something went wrong and you should carefully recheck what you did in th
 
 ### Step 8: Modify your `.bashrc` {#step-8}
 
+:::{.callout-warning}
+Loading the setup script automatically needs to be done in the container!
+:::
 In order to have the references to BOSS loaded automatically every time you log in on the server, we can add some of the steps we did above to your `bash` profile (`.bash_profile`) and _run commands_ file (`.bashrc`).
 
 :::{.column-margin}
@@ -198,7 +203,7 @@ These lines force the server to source your `.bashrc` run commands file when you
 
 ```{.bash filename=".bashrc"}
 export BOSS_INSTALL="/besfs5/users/${USER}/boss"
-export BOSS_VERSION="7.0.5"
+export BOSS_VERSION="7.1.3.b"
 CMTHOME="/cvmfs/bes3.ihep.ac.cn/bes3sw/cmthome/cmthome-${BOSS_VERSION}"
 
 source "${BOSS_INSTALL}/cmthome/setupCMT.sh"
@@ -221,10 +226,10 @@ The following summarizes all commands required to 'install' BOSS on `lxslc` on y
 
 ```bash
 BOSS_INSTALL=/besfs5/users/$USER/boss
-BOSS_VERSION=7.0.5
+BOSS_VERSION=7.1.3.b
 mkdir -p $BOSS_INSTALL/cmthome
 cd $BOSS_INSTALL/cmthome
-cp -Rf /cvmfs/bes3.ihep.ac.cn/bes3sw/cmthome/cmthome-$BOSS_VERSION/* .
+cp -Rf /cvmfs/bes3.ihep.ac.cn/bes3sw/cmthome/my/cmthome-$BOSS_VERSION/* .
 vi requirements
 ```
 

--- a/tutorials/getting-started/setup.qmd
+++ b/tutorials/getting-started/setup.qmd
@@ -66,7 +66,7 @@ Option `-p` makes `mkdir` work on arbitrary depth and ignores existing directori
 ```bash
 mkdir -p "$BOSS_INSTALL/cmthome"
 cd "$BOSS_INSTALL/cmthome"
-cp -Rf /cvmfs/bes3.ihep.ac.cn/bes3sw/cmthome/my/cmthome-$BOSS_VERSION/* .
+cp -Rf /cvmfs/bes3.ihep.ac.cn/bes3sw/cmthome/cmthome-$BOSS_VERSION/* .
 ```
 
 Note that we have omitted the version from the original folder name. You can choose to keep that number as well, but here we chose to use the convention that `cmthome` and `workarea` without a version number refers to the latest stable version of BOSS.
@@ -183,6 +183,7 @@ If not, something went wrong and you should carefully recheck what you did in th
 :::{.callout-warning}
 Loading the setup script automatically needs to be done in the container!
 :::
+
 In order to have the references to BOSS loaded automatically every time you log in on the server, we can add some of the steps we did above to your `bash` profile (`.bash_profile`) and _run commands_ file (`.bashrc`).
 
 :::{.column-margin}
@@ -227,7 +228,7 @@ BOSS_INSTALL=/besfs5/users/$USER/boss
 BOSS_VERSION=7.0.8
 mkdir -p $BOSS_INSTALL/cmthome
 cd $BOSS_INSTALL/cmthome
-cp -Rf /cvmfs/bes3.ihep.ac.cn/bes3sw/cmthome/my/cmthome-$BOSS_VERSION/* .
+cp -Rf /cvmfs/bes3.ihep.ac.cn/bes3sw/cmthome/cmthome-$BOSS_VERSION/* .
 vi requirements
 ```
 


### PR DESCRIPTION
Update login instructions to fix #76 with .ssh configuration example.
Adding setup instructions to load the CentOS container shell for BOSS 7.x and updating file pathes,