### PR TITLE
DOC: update data measurement table

### DIFF
--- a/tutorials/data/measurements.qmd
+++ b/tutorials/data/measurements.qmd
@@ -9,7 +9,7 @@ title: BESIII measurements
 | 2009      |  `02` |              $233.7 \pm 1.4$ |    $0.63\%$ | `/besfs3/offline/data/703-1/jpsi/round02/dst`     |
 | 2012      |  `05` |           $1\,086.9 \pm 6.0$ |    $0.55\%$ | `/besfs3/offline/data/703-1/jpsi/round05/dst`     |
 | 2017–2018 |  `11` |            $4.6 \times 10^3$ |  ($0.53\%$) | `/bes**3fs**/offline/data/704-1/jpsi/round11/dst` |
-| 2018–2019 |  `12` |            $4.1 \times 10^3$ |   ($0.53\%$) | `/bes**3fs**/offline/data/704-1/jpsi/round12/dst` |
+| 2018–2019 |  `12` |            $4.1 \times 10^3$ |  ($0.53\%$) | `/bes**3fs**/offline/data/704-1/jpsi/round12/dst` |
 
 - See "Determination of the number of $J/\psi$ events with inclusive $J/\psi$ decays"&nbsp;[@BESIII:2016kpv] for the calculation of the number of $J/\psi$ events in the 2009 and 2012 data samples. The total number for both is $N_{J/\psi} = (1310.6\pm7.0) \times 10^6$, which is $0.53\%$ systematic uncertainty.
 - See an indication of the number of $J/\psi$ events in [this presentation](https://indico.ihep.ac.cn/event/8795/session/3/contribution/9/material/slides/0.pdf) (requires login). Systematic uncertainty is not yet determined, but could be comparable.

--- a/tutorials/data/measurements.qmd
+++ b/tutorials/data/measurements.qmd
@@ -4,12 +4,12 @@ title: BESIII measurements
 
 ## $J/\psi$ samples
 
-| Year      | Round | $N_{J/\psi}$ ($\times 10^6$) | Uncertainty | Location                                          |
-| --------- | ----: | ---------------------------: | ----------: | ------------------------------------------------- |
-| 2009      |  `02` |              $233.7 \pm 1.4$ |    $0.63\%$ | `/besfs3/offline/data/703-1/jpsi/round02/dst`     |
-| 2012      |  `05` |           $1\,086.9 \pm 6.0$ |    $0.55\%$ | `/besfs3/offline/data/703-1/jpsi/round05/dst`     |
-| 2017–2018 |  `11` |            $4.6 \times 10^3$ |  ($0.53\%$) | `/bes**3fs**/offline/data/704-1/jpsi/round11/dst` |
-| 2018–2019 |  `12` |            $4.1 \times 10^3$ |  ($0.53\%$) | `/bes**3fs**/offline/data/704-1/jpsi/round12/dst` |
+| Year      | Round | $N_{J/\psi}$ ($\times 10^6$) | Uncertainty | Location                                      |
+| --------- | ----: | ---------------------------: | ----------: | --------------------------------------------- |
+| 2009      |  `02` |              $233.7 \pm 1.4$ |    $0.63\%$ | `/bes3fs/offline/data/708-1/jpsi/round02/dst` |
+| 2012      |  `05` |           $1\,086.9 \pm 6.0$ |    $0.55\%$ | `/bes3fs/offline/data/708-1/jpsi/round05/dst` |
+| 2017–2018 |  `11` |            $4.6 \times 10^3$ |  ($0.53\%$) | `/bes3fs/offline/data/708-1/jpsi/round11/dst` |
+| 2018–2019 |  `12` |            $4.1 \times 10^3$ |  ($0.53\%$) | `/bes3fs/offline/data/708-1/jpsi/round12/dst` |
 
 - See "Determination of the number of $J/\psi$ events with inclusive $J/\psi$ decays"&nbsp;[@BESIII:2016kpv] for the calculation of the number of $J/\psi$ events in the 2009 and 2012 data samples. The total number for both is $N_{J/\psi} = (1310.6\pm7.0) \times 10^6$, which is $0.53\%$ systematic uncertainty.
 - See an indication of the number of $J/\psi$ events in [this presentation](https://indico.ihep.ac.cn/event/8795/session/3/contribution/9/material/slides/0.pdf) (requires login). Systematic uncertainty is not yet determined, but could be comparable.

--- a/tutorials/data/measurements.qmd
+++ b/tutorials/data/measurements.qmd
@@ -9,7 +9,7 @@ title: BESIII measurements
 | 2009      |  `02` |              $233.7 \pm 1.4$ |    $0.63\%$ | `/besfs3/offline/data/703-1/jpsi/round02/dst`     |
 | 2012      |  `05` |           $1\,086.9 \pm 6.0$ |    $0.55\%$ | `/besfs3/offline/data/703-1/jpsi/round05/dst`     |
 | 2017–2018 |  `11` |            $4.6 \times 10^3$ |  ($0.53\%$) | `/bes**3fs**/offline/data/704-1/jpsi/round11/dst` |
-| 2018–2019 |  `12` |            $4.1 \times 10^3$ |   ($0.53\%) | `/bes**3fs**/offline/data/704-1/jpsi/round12/dst` |
+| 2018–2019 |  `12` |            $4.1 \times 10^3$ |   ($0.53\%$) | `/bes**3fs**/offline/data/704-1/jpsi/round12/dst` |
 
 - See "Determination of the number of $J/\psi$ events with inclusive $J/\psi$ decays"&nbsp;[@BESIII:2016kpv] for the calculation of the number of $J/\psi$ events in the 2009 and 2012 data samples. The total number for both is $N_{J/\psi} = (1310.6\pm7.0) \times 10^6$, which is $0.53\%$ systematic uncertainty.
 - See an indication of the number of $J/\psi$ events in [this presentation](https://indico.ihep.ac.cn/event/8795/session/3/contribution/9/material/slides/0.pdf) (requires login). Systematic uncertainty is not yet determined, but could be comparable.


### PR DESCRIPTION
Updating data location for BOSS version 7.0.8 according to https://docbes3.ihep.ac.cn/~offlinesoftware/index.php/Data_production_with_version_V7.0.8.
Adding missing $ in table.
