### PR TITLE
DOC: update storage paths, quota, and backup information

### DIFF
--- a/appendices/tips.qmd
+++ b/appendices/tips.qmd
@@ -63,7 +63,7 @@ VSCode Remote SSH installs some files into your home directory on the server, in
 
 ```json
   "remote.SSH.serverInstallPath": {
-    "ihep": "/besfs5/users/<USERNAME>"
+    "ihep": "/besfs10/users/<USERNAME>"
   },
 ```
 
@@ -88,8 +88,8 @@ As an alternative you can move the `.vscode`folder and create a symbolic link in
 
 ```bash
 cd ~
-mkdir /besfs5/users/$USER/.vscode-server
-ln -s /besfs5/users/$USER/.vscode-server
+mkdir /besfs10/users/$USER/.vscode-server
+ln -s /besfs10/users/$USER/.vscode-server
 ```
 
 ## `.vscode-server` already exists
@@ -98,8 +98,8 @@ An existing `.vscode-server` folder in your home directory can cause Visual Stud
 
 ```bash
 cd ~
-mv -f .vscode-server /besfs5/users/$USER/
-ln -s /besfs5/users/$USER/.vscode-server
+mv -f .vscode-server /besfs10/users/$USER/
+ln -s /besfs10/users/$USER/.vscode-server
 ```
 
 :::

--- a/packages/analysis/topoana/index.qmd
+++ b/packages/analysis/topoana/index.qmd
@@ -16,7 +16,7 @@ The problem with inclusive samples, however, is that they can include thousands 
 All versions of the package can be found here on [the IHEP server](/tutorials/getting-started/server.qmd#accessing-the-server): <!-- cspell:ignore zhouxy -->
 
 ```default
-/besfs5/users/zhouxy/tools/topoana
+/besfs10/users/zhouxy/tools/topoana
 ```
 
 ## Preparing initial event selection
@@ -53,7 +53,7 @@ See also [decayFromGenerator](https://bes3.to.infn.it/Boss/7.0.2/html/classEvent
 All versions of `MctruthForTopo` can be found here on the IHEP server:
 
 ```bash
-/besfs5/users/zhouxy/workarea/workarea-6.6.5/Analysis/Physics/MctruthForTopoAnaAlg
+/besfs10/users/zhouxy/workarea/workarea-6.6.5/Analysis/Physics/MctruthForTopoAnaAlg
 ```
 
 You may choose a different version of BOSS than `6.6.5`, the one used above. If you have sourced one of these versions (using `bash cmt/setup`), you can run it by adding the following lines to your job options:

--- a/tutorials/data/index.qmd
+++ b/tutorials/data/index.qmd
@@ -21,9 +21,9 @@ Inventories of the latest file locations are found on the Offline Software pages
 - [Raw data](https://docbes3.ihep.ac.cn/~offlinesoftware/index.php/Raw_Data)
 - [Reconstructed data](https://docbes3.ihep.ac.cn/~offlinesoftware/index.php/Production)
 
-In general, all data files are located on the BESIII file system (`besfs5`) folders on the [IHEP Server](/tutorials/getting-started/server.qmd). There are a few different folders, because the files have been distributed to different servers.
+In general, all data files are located on the BESIII file system (`besfs10`) folders on the [IHEP Server](/tutorials/getting-started/server.qmd). There are a few different folders, because the files have been distributed to different servers.
 
-- `besfs5`: contains user files only
+- `besfs10`: contains user files only
 - `besfs2`: a symbolic link that points to `/besfs3/offline/data/besfs2`. Contains inclusive Monte Carlo samples.
 - `besfs3`: file system that contains files of the runs before 2018
 - `bes3fs`: a newer file system that contains for instance 2018 data

--- a/tutorials/getting-started/data-quota.qmd
+++ b/tutorials/getting-started/data-quota.qmd
@@ -9,16 +9,21 @@ When you have logged into the server, you usually start in your home (`~`) folde
 <!-- prettier-ignore-start -->
 | Path                                      |            Data quota | Max. files | Note
 | ----------------------------------------- | --------------------: | ---------: | -------------------------- |
-| `/afs/ihep.ac.cn/users/${USER:0:1}/$USER` | <font color=red>500 MB</font> |    | home (`~`)
-| `/besfs5/users/$USER`                     | <font color=green>_no quota_</font> |  1,000,000 | fastest connection
-| `/scratchfs2/bes/$USER`                   |                500 GB |    200,000 | large data files
-| `/workfs2/bes/$USER`                      |                  5 GB |     50,000 |
+| `/afs/ihep.ac.cn/users/${USER:0:1}/$USER` | <font color=red>500 MB</font> |     | home (`~`)
+| ~~`/besfs5/users/$USER`~~                 | ~~_no quota_~~                      |  ~~1,000,000~~ | <font color=red>deprecated</font>
+| `/besfs10/users/$USER`                    | <font color=green>_no quota_</font> | <font color=green>_no quota_</font> | newer, faster storage
+| `/scratchfs2/bes/$USER`                   |                500 GB |     200,000 | large data files
+| `/workfs2/bes/$USER`                      |                  5 GB |      50,000 |
 <!-- prettier-ignore-end -->
 
 :::
 
 ::: {.callout-warning}
 Previously existing `/scratchfs` is retired by July 31<sup>st</sup>, 2026 and replaced by `/scratchfs2`.
+:::
+
+::: {.callout-warning}
+`/besfs5` will no longer be available from 2027. Please migrate to `/besfs10` instead.
 :::
 
 Official information on the quota can be found [here](http://afsapply.ihep.ac.cn/cchelp/en/experiments/BES/#712-storage) (BESIII) and [here](https://afsapply.ihep.ac.cn/cchelp/en/appendix/storage-allocation-and-quota) (IHEP). You can check your quota by running the following commands:
@@ -33,10 +38,10 @@ Official information on the quota can be found [here](http://afsapply.ihep.ac.cn
 fs listquota /afs/ihep.ac.cn/users/${USER:0:1}/$USER
 ```
 
-## `/besfs5`
+## `/besfs10`
 
 ```bash
-lfs quota -u $USER /besfs5
+lfs quota -u $USER /besfs10
 ```
 
 ## `/scratchfs2`
@@ -54,10 +59,10 @@ lfs quota -u $USER /workfs2
 :::
 
 ::::{.callout-tip}
-The best setup is to use `/besfs5` for your code and small data files. You can use symbolic links to link from your home directory to `/besfs5` and avoid quota issues under `/afs`. Example:
+The best setup is to use `/besfs10` for your code and small data files. You can use symbolic links to link from your home directory to `/besfs10` and avoid quota issues under `/afs`. Example:
 
 ```bash
-ln -s /besfs5/users/$USER/.cache ~/.cache
+ln -s /besfs10/users/$USER/.cache ~/.cache
 ```
 
 ::::

--- a/tutorials/getting-started/server.qmd
+++ b/tutorials/getting-started/server.qmd
@@ -75,7 +75,7 @@ Some other important directories for the BESIII Collaboration are the following:
   - `/cvmfs/bes3.ihep.ac.cn/bes3sw/Boss` (also referred to with `$BesArea`)
 - [Raw data files](https://docbes3.ihep.ac.cn/~offlinesoftware/index.php/Raw_Data)
   - `/bes3fs/offline/data/raw`
-  - `/besfs5/offline/data/randomtrg` (random trigger data) <!-- cspell:ignore randomtrg -->
+  - `/besfs10/offline/data/randomtrg` (random trigger data) <!-- cspell:ignore randomtrg -->
 - [Reconstructed data sets](https://docbes3.ihep.ac.cn/~offlinesoftware/index.php/Jpsi_data) (see also [Production](https://docbes3.ihep.ac.cn/~offlinesoftware/index.php/Production)) for different versions can be found with:
 
   ```bash

--- a/tutorials/getting-started/setup.qmd
+++ b/tutorials/getting-started/setup.qmd
@@ -22,7 +22,7 @@ In this section, you will learn how to 'install' BOSS. Since BOSS has already be
 
 In this part of the tutorial, we will do two things: (1) setup the necessary references to BOSS and (2) preparing your `workarea` folder. You will be developing your own BOSS packages (mainly code for event selection) in this `workarea` folder. Next to your `workarea`, there will be a [CMT](intro.qmd#cmt) folder (`cmthome`), which manages access to the BOSS installation. In the end you will have a file structure like this:
 
-- `/besfs5/users/$USER/boss/` (local install area)
+- `/besfs10/users/$USER/boss/` (local install area)
   - `cmthome` (manages access to BOSS)
   - `workarea` (contains your analysis code)
     - `MyEventSelectionPackage` (could be several packages)
@@ -32,14 +32,14 @@ In this part of the tutorial, we will do two things: (1) setup the necessary ref
 For the sake of making this tutorial work in a general setting, we will first define a `bash` variable here (you can just execute this command in `bash`):
 
 ```bash
-BOSS_INSTALL="/besfs5/users/${USER}/boss"
+BOSS_INSTALL="/besfs10/users/${USER}/boss"
 ```
 
 :::{.callout-note collapse="true"}
 The above is equivalent to
 
 ```bash
-BOSS_INSTALL=/besfs5/users/$USER/boss
+BOSS_INSTALL=/besfs10/users/$USER/boss
 ```
 
 Why the quotation marks (`"..."`) and curly braces (`{...}`)? It's just a good habit in `bash` scripting to avoid bugs and improve readability. The quotation marks ensure that we are storing a string here and allow you to use spaces, while the curly braces clarify the extend of the variable name (`USER` in this case).
@@ -95,7 +95,7 @@ path_prepend CMTPATH "${WorkArea}"
 The first line needs to be modified so that the variable `${WorkArea}` points to your quotation marks with the path to your workarea. In our case, the first line becomes:
 
 ```bash
-macro WorkArea "/besfs5/users/$USER/boss/workarea"
+macro WorkArea "/besfs10/users/$USER/boss/workarea"
 ```
 
 :::{.callout-node collapse=true title="What is this `requirements` file actually?"}
@@ -123,7 +123,7 @@ echo $CMTPATH
 If everything went well, it should print something like:
 
 ```bash
-/besfs5/users/$USER/boss/workarea:
+/besfs10/users/$USER/boss/workarea:
 /cvmfs/bes3.ihep.ac.cn/bes3sw/Boss/7.0.5:
 /cvmfs/bes3.ihep.ac.cn/bes3sw/ExternalLib/SLC6/ExternalLib/gaudi/GAUDI_v23r9:
 /cvmfs/bes3.ihep.ac.cn/bes3sw/ExternalLib/SLC6/ExternalLib/LCGCMT/LCGCMT_65a
@@ -205,7 +205,7 @@ fi
 These lines force the server to source your `.bashrc` run commands file when you log in. In that file, you should add the following lines: <!-- cspell:ignore sysgroup -->
 
 ```{.bash filename=".bashrc"}
-export BOSS_INSTALL="/besfs5/users/${USER}/boss"
+export BOSS_INSTALL="/besfs10/users/${USER}/boss"
 export BOSS_VERSION="7.0.8"
 CMTHOME="/cvmfs/bes3.ihep.ac.cn/bes3sw/cmthome/cmthome-${BOSS_VERSION}"
 
@@ -228,7 +228,7 @@ source ~/.bashrc`
 The following summarizes all commands required to 'install' BOSS on `lxlogin` on your IHEP user account. If you don't know what you are doing, go through the sections above to understand what's going on here.
 
 ```bash
-BOSS_INSTALL=/besfs5/users/$USER/boss
+BOSS_INSTALL=/besfs10/users/$USER/boss
 BOSS_VERSION=7.0.8
 mkdir -p $BOSS_INSTALL/cmthome
 cd $BOSS_INSTALL/cmthome
@@ -236,7 +236,7 @@ cp -Rf /cvmfs/bes3.ihep.ac.cn/bes3sw/cmthome/cmthome-$BOSS_VERSION/* .
 vi requirements
 ```
 
-Now uncomment and change the lines containing `WorkArea` to `/besfs5/users/$USER/boss/workarea`. Then:
+Now uncomment and change the lines containing `WorkArea` to `/besfs10/users/$USER/boss/workarea`. Then:
 
 ```bash
 source setupCMT.sh
@@ -257,7 +257,7 @@ If you want, you can add the `source` commands above your `.bash_profile` so tha
 ```bash
 OUT_FILE=~/.bash_profile
 echo >> $OUT_FILE
-echo "export BOSS_INSTALL=/besfs5/users/$USER/boss" >> $OUT_FILE
+echo "export BOSS_INSTALL=/besfs10/users/$USER/boss" >> $OUT_FILE
 echo "source \$BOSS_INSTALL/cmthome/setupCMT.sh"  >> $OUT_FILE
 echo "source \$BOSS_INSTALL/cmthome/setup.sh"  >> $OUT_FILE
 echo "source \$BOSS_INSTALL/workarea/TestRelease/TestRelease-*/cmt/setup.sh" >> $OUT_FILE


### PR DESCRIPTION
- Fixes #100
- Fixes #107
- Fixes #101

Combines three related updates to the storage documentation, since they all touch the same table on the [Data quota](https://bes3.readthedocs.io/tutorials/getting-started/data-quota.html) page.

### `/besfs5` → `/besfs10` (#100)

Picks up the existing `MAINT/besfs10` work and adds a row for `/home/bes/$USER`, noting that it is a symlink to `/besfs10/homebes` and is the path IHEP recommends, because it should survive the next file system migration. `/home/bes` and `/workfs2` are now also mentioned as alternatives for the BOSS install folder.

### Storage quota (#107)

The table claimed `/besfs10` has no quota. In reality the quota is applied **per directory** (50 GB), which `lfs quota -u $USER` does not reveal — so jobs die halfway through with `Disk quota exceeded` and no prior warning. `lfs_dir` is now documented as the command that shows the limit you actually run into.

### Backup information (#101)

Adds a **Backup** column to the table, plus a note that anything not under version control belongs on a backed-up file system, and that caches and large data files do not. Step 1 of the setup tutorial now warns that `/besfs10` is not backed up and recommends keeping the `workarea` in a Git repository.

> [!NOTE]
> The 50 GB figure and the backup column are taken from the discussion in #100 and #107 — <http://afsapply.ihep.ac.cn> was not reachable to verify them against the official pages, so please correct if these are off. The maximum file count for `/besfs10` is listed as _not documented_ rather than carrying over the old `1,000,000` from `/besfs5`.